### PR TITLE
Suggested change to Chrome cleanup logic.

### DIFF
--- a/DiskCleanup.bat
+++ b/DiskCleanup.bat
@@ -173,32 +173,34 @@ ECHO Cleaning CCM Cache
 :GoogleChrome
  ECHO Cleaning Google Chrome Cache
 
-	For /d %%u in (%systemdrive%\users\*) do (
-		SET "chromeDataDir=AppData\Local\Google\Chrome\User Data\"
-		REM Create a temporary file to store the folder list
-		SET "folderListFile=%TEMP%\chrome_profiles.txt"
+	SETLOCAL EnableDelayedExpansion
+	For /d %%u in ("%systemdrive%\users\*") do (
+		SET "chromeDataDir=%%u\AppData\Local\Google\Chrome\User Data"
+		SET "folderListFile=!TEMP!\chrome_profiles.txt"
 
 		REM Find the matching folders and store them in the temporary file
-		FOR /D %%A IN ("%%u\%chromeDataDir%\Default" "%%u\%chromeDataDir%\Profile *") DO (
-			ECHO %%~nA >> "%folderListFile%"
+		FOR /D %%A IN ("!chromeDataDir!\Default" "!chromeDataDir!\Profile *") DO (
+			ECHO %%~nA>> "!folderListFile!"
 		)
 
-		IF EXIST "%folderListFile" (
-			FOR /F "usebackq tokens=*" %%B IN ("%folderListFile%") DO (
-					del /q /s /f "%%u\%chromeDataDir%\%%B\Cache\cache_data\"	>nul 2>&1
-					del /q /s /f "%%u\%chromeDataDir%\%%B\Code Cache\js\"	>nul 2>&1
-					del /q /s /f "%%u\%chromeDataDir%\%%B\Code Cache\wasm\"	>nul 2>&1
-					del /q /s /f "%%u\%chromeDataDir%\%%B\Service Worker\CacheStorage\"	>nul 2>&1
-					del /q /s /f "%%u\%chromeDataDir%\%%B\Service Worker\ScriptCache\"	>nul 2>&1
-					del /q /s /f "%%u\%chromeDataDir%\%%B\gpucache\"	>nul 2>&1
+		IF EXIST "!folderListFile!" (
+			FOR /F "usebackq tokens=*" %%B IN ("!folderListFile!") DO (
+					del /q /s /f "!chromeDataDir!\%%B\Cache\cache_data\"	>nul 2>&1
+					del /q /s /f "!chromeDataDir!\%%B\Code Cache\js\"	>nul 2>&1
+					del /q /s /f "!chromeDataDir!\%%B\Code Cache\wasm\"	>nul 2>&1
+					del /q /s /f "!chromeDataDir!\%%B\Service Worker\CacheStorage\"	>nul 2>&1
+					del /q /s /f "!chromeDataDir!\%%B\Service Worker\ScriptCache\"	>nul 2>&1
+					del /q /s /f "!chromeDataDir!\%%B\gpucache\"	>nul 2>&1
 				)
-
-			del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\component_crx_cache\"	>nul 2>&1
-			del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\GrShaderCache\"	>nul 2>&1
-			del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\ShaderChache\"	>nul 2>&1
-
 		)
+		del /q /s /f "!chromeDataDir!\component_crx_cache\"	>nul 2>&1
+		del /q /s /f "!chromeDataDir!\GrShaderCache\"	>nul 2>&1
+		del /q /s /f "!chromeDataDir!\ShaderChache\"	>nul 2>&1
+
+		REM Clean up the temporary file after each profile is processed
+    	IF EXIST "!folderListFile!" DEL /Q /F "!folderListFile!"
 	)
+	ENDLOCAL
 		
 :EdgeChromiumCache
 ECHO Cleaning Edge -Chromium- Cache

--- a/DiskCleanup.bat
+++ b/DiskCleanup.bat
@@ -174,53 +174,32 @@ ECHO Cleaning CCM Cache
  ECHO Cleaning Google Chrome Cache
 
 	For /d %%u in (%systemdrive%\users\*) do (
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Default\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 1\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 2\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 3\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 4\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 5\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 6\Cache\cache_data\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Default\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 1\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 2\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 3\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 4\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 5\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 6\Code Cache\js\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Default\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 1\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 2\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 3\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 4\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 5\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 6\Code Cache\wasm\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Default\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 1\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 2\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 3\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 4\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 5\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 6\Service Worker\CacheStorage\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Default\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 1\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 2\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 3\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 4\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 5\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 6\Service Worker\ScriptCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\component_crx_cache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\GrShaderCache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\ShaderChache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Default\gpucache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 1\gpucache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 2\gpucache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 3\gpucache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 4\gpucache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 5\gpucache\"	>nul 2>&1
-	del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\Profile 6\gpucache\"	>nul 2>&1
-	)
+		SET "chromeDataDir=AppData\Local\Google\Chrome\User Data\"
+		REM Create a temporary file to store the folder list
+		SET "folderListFile=%TEMP%\chrome_profiles.txt"
 
+		REM Find the matching folders and store them in the temporary file
+		FOR /D %%A IN ("%%u\%chromeDataDir%\Default" "%%u\%chromeDataDir%\Profile *") DO (
+			ECHO %%~nA >> "%folderListFile%"
+		)
+
+		IF EXIST "%folderListFile" (
+			FOR /F "usebackq tokens=*" %%B IN ("%folderListFile%") DO (
+					del /q /s /f "%%u\%chromeDataDir%\%%B\Cache\cache_data\"	>nul 2>&1
+					del /q /s /f "%%u\%chromeDataDir%\%%B\Code Cache\js\"	>nul 2>&1
+					del /q /s /f "%%u\%chromeDataDir%\%%B\Code Cache\wasm\"	>nul 2>&1
+					del /q /s /f "%%u\%chromeDataDir%\%%B\Service Worker\CacheStorage\"	>nul 2>&1
+					del /q /s /f "%%u\%chromeDataDir%\%%B\Service Worker\ScriptCache\"	>nul 2>&1
+					del /q /s /f "%%u\%chromeDataDir%\%%B\gpucache\"	>nul 2>&1
+				)
+
+			del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\component_crx_cache\"	>nul 2>&1
+			del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\GrShaderCache\"	>nul 2>&1
+			del /q /s /f "%%u\AppData\Local\Google\Chrome\User Data\ShaderChache\"	>nul 2>&1
+
+		)
+	)
+		
 :EdgeChromiumCache
 ECHO Cleaning Edge -Chromium- Cache
 


### PR DESCRIPTION
The PR removes the hardcoded Chrome profiles and changes it to find existing profiles and iterate over them to delete. Instead of being limited to Default and Profile [1-6], this will handle any number of profiles.

Should also add checks that the files even exist before trying to delete.

Not thoroughly tested. I don't have an environment to throw this on for easy testing.